### PR TITLE
Fix archive rewrite rules

### DIFF
--- a/classes/class-woothemes-testimonials.php
+++ b/classes/class-woothemes-testimonials.php
@@ -96,7 +96,7 @@ class Woothemes_Testimonials {
 			'query_var' => true,
 			'rewrite' => array( 'slug' => 'testimonial' ),
 			'capability_type' => 'post',
-			'has_archive' => array( 'slug' => 'testimonials' ),
+			'has_archive' => 'testimonials',
 			'hierarchical' => false,
 			'supports' => array( 'title', 'editor', 'thumbnail', 'page-attributes' ), 
 			'menu_position' => 5, 


### PR DESCRIPTION
The `has_archive` argument of the [register_post_type](http://codex.wordpress.org/Function_Reference/register_post_type) function only accepts a bool or string value. An array is being passed in this situation, which is causing incorrect rewrite rules to be generated.
