### PR TITLE
Add filters for URL slugs

### DIFF
--- a/classes/class-woothemes-testimonials.php
+++ b/classes/class-woothemes-testimonials.php
@@ -88,6 +88,10 @@ class Woothemes_Testimonials {
 			'menu_name' => __( 'Testimonials', 'woothemes-testimonials' )
 
 		);
+
+		$single_slug = apply_filters( 'woothemes_testimonials_single_slug', _x( 'testimonial', 'single post url slug', 'woothemes-testimonials' ) );
+		$archive_slug = apply_filters( 'woothemes_testimonials_archive_slug', _x( 'testimonials', 'post archive url slug', 'woothemes-testimonials' ) );
+
 		$args = array(
 			'labels' => $labels,
 			'public' => true,
@@ -95,9 +99,9 @@ class Woothemes_Testimonials {
 			'show_ui' => true,
 			'show_in_menu' => true,
 			'query_var' => true,
-			'rewrite' => array( 'slug' => 'testimonial' ),
+			'rewrite' => array( 'slug' => $single_slug ),
 			'capability_type' => 'post',
-			'has_archive' => 'testimonials',
+			'has_archive' => $archive_slug,
 			'hierarchical' => false,
 			'supports' => array( 'title', 'editor', 'thumbnail', 'page-attributes' ),
 			'menu_position' => 5,
@@ -517,6 +521,7 @@ class Woothemes_Testimonials {
 	 */
 	public function activation () {
 		$this->register_plugin_version();
+		$this->flush_rewrite_rules();
 	} // End activation()
 
 	/**
@@ -530,6 +535,17 @@ class Woothemes_Testimonials {
 			update_option( 'woothemes-testimonials' . '-version', $this->version );
 		}
 	} // End register_plugin_version()
+
+	/**
+	 * Flush the rewrite rules
+	 * @access public
+	 * @since 1.3.2
+	 * @return void
+	 */
+	private function flush_rewrite_rules () {
+		$this->register_post_type();
+		flush_rewrite_rules();
+	} // End flush_rewrite_rules()
 
 	/**
 	 * Ensure that "post-thumbnails" support is available for those themes that don't register it.

--- a/lang/woothemes-testimonials-en_GB.po
+++ b/lang/woothemes-testimonials-en_GB.po
@@ -1,15 +1,16 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Testimonials v1.3.0\n"
+"Project-Id-Version: Testimonials v1.3.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2013-04-30 12:40:13+0000\n"
+"PO-Revision-Date: 2013-07-31 02:00:10+0000\n"
 "Last-Translator: Matty <matt@woothemes.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: CSL v1.x\n"
 "X-Poedit-Language: English\n"
 "X-Poedit-Country: UNITED KINGDOM\n"
 "X-Poedit-SourceCharset: utf-8\n"
@@ -106,110 +107,110 @@ msgstr ""
 msgid "No %s Found In Trash"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:159
+#: classes/class-woothemes-testimonials.php:163
 #@ woothemes-testimonials
 msgid "Image"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:193
+#: classes/class-woothemes-testimonials.php:197
 #, php-format
 #@ woothemes-testimonials
 msgid "Testimonial updated. %sView testimonial%s"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:194
+#: classes/class-woothemes-testimonials.php:198
 #@ woothemes-testimonials
 msgid "Custom field updated."
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:195
+#: classes/class-woothemes-testimonials.php:199
 #@ woothemes-testimonials
 msgid "Custom field deleted."
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:196
+#: classes/class-woothemes-testimonials.php:200
 #@ woothemes-testimonials
 msgid "Testimonial updated."
 msgstr ""
 
 #. translators: %s: date and time of the revision
-#: classes/class-woothemes-testimonials.php:198
+#: classes/class-woothemes-testimonials.php:202
 #, php-format
 #@ woothemes-testimonials
 msgid "Testimonial restored to revision from %s"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:199
+#: classes/class-woothemes-testimonials.php:203
 #, php-format
 #@ woothemes-testimonials
 msgid "Testimonial published. %sView testimonial%s"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:200
-#@ default
-msgid "Testimonial saved."
-msgstr ""
-
-#: classes/class-woothemes-testimonials.php:201
-#, php-format
-#@ woothemes-testimonials
-msgid "Testimonial submitted. %sPreview testimonial%s"
-msgstr ""
-
-#: classes/class-woothemes-testimonials.php:202
-#, php-format
-#@ woothemes-testimonials
-msgid "Testimonial scheduled for: %1$s. %2$sPreview testimonial%3$s"
-msgstr ""
-
 #: classes/class-woothemes-testimonials.php:204
 #@ default
-msgid "M j, Y @ G:i"
+msgid "Testimonial saved."
 msgstr ""
 
 #: classes/class-woothemes-testimonials.php:205
 #, php-format
 #@ woothemes-testimonials
+msgid "Testimonial submitted. %sPreview testimonial%s"
+msgstr ""
+
+#: classes/class-woothemes-testimonials.php:206
+#, php-format
+#@ woothemes-testimonials
+msgid "Testimonial scheduled for: %1$s. %2$sPreview testimonial%3$s"
+msgstr ""
+
+#: classes/class-woothemes-testimonials.php:208
+#@ default
+msgid "M j, Y @ G:i"
+msgstr ""
+
+#: classes/class-woothemes-testimonials.php:209
+#, php-format
+#@ woothemes-testimonials
 msgid "Testimonial draft updated. %sPreview testimonial%s"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:219
+#: classes/class-woothemes-testimonials.php:223
 #@ woothemes-testimonials
 msgid "Testimonial Details"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:318
+#: classes/class-woothemes-testimonials.php:322
 #@ woothemes-testimonials
 msgid "Enter the customer's name here"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:344
+#: classes/class-woothemes-testimonials.php:348
 #@ woothemes-testimonials
 msgid "Gravatar E-mail Address"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:345
+#: classes/class-woothemes-testimonials.php:349
 #, php-format
 #@ woothemes-testimonials
 msgid "Enter in an e-mail address, to use a %sGravatar%s, instead of using the \"Featured Image\"."
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:352
+#: classes/class-woothemes-testimonials.php:356
 #@ woothemes-testimonials
 msgid "Byline"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:353
+#: classes/class-woothemes-testimonials.php:357
 #@ woothemes-testimonials
 msgid "Enter a byline for the customer giving this testimonial (for example: \"CEO of WooThemes\")."
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:360
+#: classes/class-woothemes-testimonials.php:364
 #@ woothemes-testimonials
 msgid "URL"
 msgstr ""
 
-#: classes/class-woothemes-testimonials.php:361
+#: classes/class-woothemes-testimonials.php:365
 #@ woothemes-testimonials
 msgid "Enter a URL that applies to this customer (for example: http://woothemes.com/)."
 msgstr ""
@@ -387,5 +388,17 @@ msgstr ""
 #: classes/class-woothemes-widget-testimonials.php:219
 #@ woothemes-testimonials
 msgid "All"
+msgstr ""
+
+#: classes/class-woothemes-testimonials.php:92
+#@ woothemes-testimonials
+msgctxt "single post url slug"
+msgid "testimonial"
+msgstr ""
+
+#: classes/class-woothemes-testimonials.php:93
+#@ woothemes-testimonials
+msgctxt "post archive url slug"
+msgid "testimonials"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Testimonials by WooThemes ===
-Contributors: woothemes, mattyza, jameskoster
+Contributors: woothemes, mattyza, jameskoster, hlashbrooke
 Donate link: http://woothemes.com/
 Tags: testimonials, widget, shortcode, template-tag, feedback, customers
 Requires at least: 3.4.2
-Tested up to: 3.5.1
-Stable tag: 1.3.1
+Tested up to: 3.5.2
+Stable tag: 1.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -96,6 +96,10 @@ We encourage everyone to contribute their ideas, thoughts and code snippets. Thi
 
 == Upgrade Notice ==
 
+= 1.3.2 =
+* Adds filters for the single testimonials and testimonial archives URL slugs
+* Adds a flush_rewrite_rules() call on plugin activation
+
 = 1.3.1 =
 * Fixes bug where testimonial text doesn't display (incorrectly placed action hook).
 
@@ -118,6 +122,12 @@ We encourage everyone to contribute their ideas, thoughts and code snippets. Thi
 * Initial release. Woo!
 
 == Changelog ==
+
+= 1.3.2 =
+* 2013-08-01.
+* Adds "woothemes_testimonials_single_slug" as a filter for the single testimonials URL slug
+* Adds "woothemes_testimonials_archive_slug" as a filter for the testimonials archive URL slug
+* Adds a flush_rewrite_rules() call on plugin activation
 
 = 1.3.1 =
 * 2013-04-30.

--- a/woothemes-testimonials.php
+++ b/woothemes-testimonials.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://woothemes.com/
  * Description: Hi, I'm your testimonials management plugin for WordPress. Show off what your customers or website users are saying about your business and how great they say you are, using our shortcode, widget or template tag.
  * Author: WooThemes
- * Version: 1.3.1
+ * Version: 1.3.2
  * Author URI: http://woothemes.com/
  *
  * @package WordPress
@@ -19,5 +19,5 @@ require_once( 'woothemes-testimonials-template.php' );
 require_once( 'classes/class-woothemes-widget-testimonials.php' );
 global $woothemes_testimonials;
 $woothemes_testimonials = new Woothemes_Testimonials( __FILE__ );
-$woothemes_testimonials->version = '1.3.1';
+$woothemes_testimonials->version = '1.3.2';
 ?>


### PR DESCRIPTION
- Adds "woothemes_testimonials_single_slug" as a filter for the single testimonials URL slug
- Adds "woothemes_testimonials_archive_slug" as a filter for the testimonials archive URL slug
- Adds a flush_rewrite_rules() call on plugin activation
