### PR TITLE
Set with_front to False

### DIFF
--- a/classes/class-woothemes-testimonials.php
+++ b/classes/class-woothemes-testimonials.php
@@ -95,7 +95,7 @@ class Woothemes_Testimonials {
 			'show_ui' => true,
 			'show_in_menu' => true,
 			'query_var' => true,
-			'rewrite' => array( 'slug' => 'testimonial' ),
+			'rewrite' => array( 'slug' => 'testimonial', 'with_front' => false ),
 			'capability_type' => 'post',
 			'has_archive' => 'testimonials',
 			'hierarchical' => false,


### PR DESCRIPTION
I have used this for several clients, and run into this issue several times, where the url is not /testimonials/ due to the settings set in the WordPress admin permalink settings.
