### PR TITLE
Update for Testimonials Slug 

### DIFF
--- a/classes/class-woothemes-testimonials-taxonomy.php
+++ b/classes/class-woothemes-testimonials-taxonomy.php
@@ -81,7 +81,15 @@ class Woothemes_Testimonials_Taxonomy {
 	 * @return  array Default arguments.
 	 */
 	private function _get_default_args () {
-		return array( 'labels' => $this->_get_default_labels(), 'public' => true, 'hierarchical' => true, 'show_ui' => true, 'show_admin_column' => true, 'query_var' => true, 'show_in_nav_menus' => false, 'show_tagcloud' => false );
+		return array(
+			'labels' => $this->_get_default_labels(),
+			'public' => true, 'hierarchical' => true,
+			'show_ui' => true,
+			'show_admin_column' => true,
+			'query_var' => true,
+			'show_in_nav_menus' => false,
+			'show_tagcloud' => false,
+			'rewrite' => array( 'slug' => 'testimonials', 'with_front' => false ) );
 	} // End _get_default_args()
 
 	/**


### PR DESCRIPTION
It was requested I create a new pull request to the 1-5-0 release. I organized the array for better readability. Changed  the slug to be /testimonials/  and set 'with_front' to false. 
