### PR TITLE
Support Excerpts

### DIFF
--- a/classes/class-woothemes-testimonials.php
+++ b/classes/class-woothemes-testimonials.php
@@ -103,7 +103,7 @@ class Woothemes_Testimonials {
 			'capability_type' => 'post',
 			'has_archive' => $archive_slug,
 			'hierarchical' => false,
-			'supports' => array( 'title', 'author' ,'editor', 'thumbnail', 'page-attributes' ),
+			'supports' => array( 'title', 'author' ,'editor', 'thumbnail', 'excerpt', 'page-attributes' ),
 			'menu_position' => 5,
 			'menu_icon' => ''
 		);


### PR DESCRIPTION
Some of the testimonials used are real long, and I want to show the full one by default, but simply supporting excerpts in the post type allows me to do:

```
/* Show Excerpt in Testimonials Widget */

function woo_exchange_excerpt($post) {
    global $post;
    if ( $post->post_excerpt && !is_page('Customer Testimonials') ) {
        return $post->post_excerpt;
    } else {
        return $post->post_content;
    }
}

add_filter( 'woothemes_testimonials_content', 'woo_exchange_excerpt', 10, 2 );
```
