### PR TITLE
Disable with_front for testimonial categories

### DIFF
--- a/classes/class-woothemes-testimonials-taxonomy.php
+++ b/classes/class-woothemes-testimonials-taxonomy.php
@@ -89,7 +89,8 @@ class Woothemes_Testimonials_Taxonomy {
 			'show_admin_column' => true,
 			'query_var'         => true,
 			'show_in_nav_menus' => false,
-			'show_tagcloud'     => false
+			'show_tagcloud'     => false,
+			'rewrite' => array( 'slug' => 'testimonials', 'with_front' => false ) );
 		);
 	} // End _get_default_args()
 


### PR DESCRIPTION
Set default slug to /testimonials/category-name/ and set with_front to false. 
