### PR TITLE
Don't override global $post

### DIFF
--- a/woothemes-testimonials-template.php
+++ b/woothemes-testimonials-template.php
@@ -29,7 +29,6 @@ if ( ! function_exists( 'woothemes_testimonials' ) ) {
  * @return string
  */
 function woothemes_testimonials ( $args = '' ) {
-	global $post;
 
 	$defaults = apply_filters( 'woothemes_testimonials_default_args', array(
 		'limit' 			=> 5,


### PR DESCRIPTION
Because the `woothemes_testimonials()` function declares the global `$post` object and then uses the variable name `$post` when [looping over testimonials](https://github.com/thenbrent/testimonials/blob/ba8655d335dd5872e0b7fab64549f9c2e55a0147/woothemes-testimonials-template.php#L91), it overrides the global `$post` object. 

This means anything that needs to access the current `$post` after the `[woothemes_testimonials]` shortcode will actually be left only with access the last testimonial, not the current post object.

I didn't see anywhere the global `$post` object was actually used in the function, and I suspect it's not intentional to override the global post.
