### PR TITLE
Revert "Dont override global $post variable."

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -131,10 +131,9 @@ We encourage everyone to contribute their ideas, thoughts and code snippets. Thi
 == Changelog ==
 
 = 1.5.2 =
-* 2014-07-02.
+* 2014-04-14.
 * Tweak - If a URL is set the avatar will link to it.
 * Tweak - More tag works as expected.
-* Fix - Dont override global $post variable.
 
 = 1.5.1 =
 * 2014-03-26.

--- a/woothemes-testimonials-template.php
+++ b/woothemes-testimonials-template.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'woothemes_testimonials' ) ) {
  * @return string
  */
 function woothemes_testimonials ( $args = '' ) {
-	global $more;
+	global $post, $more;
 
 	$defaults = apply_filters( 'woothemes_testimonials_default_args', array(
 		'limit' 			=> 5,


### PR DESCRIPTION
I was wrong in #56. Without declaring the global `$post`, the `setup_postdata()` doesn't work correctly (it needs a reference to the global `$post` variable), meaning template tags like `get_the_ID()` etc. will output the wrong data on the testimonial.

This reverts SHA: 1cd2e6266438851c04c18d68956b7f9f673c3c12 to restore the global declaration.

The issue I had with the global `$post` pointing to the last testimonial found in the subquery is because my request is on an Ajax call, where `wp_reset_postdata()` doesn't have a main query to reset too.
