### PR TITLE
default taxonomy args now filterable, follow-up for #33

### DIFF
--- a/classes/class-woothemes-testimonials-taxonomy.php
+++ b/classes/class-woothemes-testimonials-taxonomy.php
@@ -123,7 +123,7 @@ class Woothemes_Testimonials_Taxonomy {
 	 * @return  void
 	 */
 	public function register () {
-		register_taxonomy( esc_attr( $this->token ), esc_attr( $this->post_type ), (array)$this->args );
+		register_taxonomy( esc_attr( $this->token ), esc_attr( $this->post_type ), (array)apply_filters( 'woothemes_testimonials_taxonomy_args', $this->args ) );
 	} // End register()
 } // End Class
 ?>


### PR DESCRIPTION
Because it only makes sense from a filtering consistency standpoint.

There's plenty of use cases. People might call a "testimonial" with a
variety of names ranging from a "case study" to "success story".
Accompanying "Categories" may need to called "Industries" etc.

Small enough change not to hurt anything while gaining flexibility.
