### PR TITLE
Update class-woothemes-widget-testimonials.php

### DIFF
--- a/classes/class-woothemes-widget-testimonials.php
+++ b/classes/class-woothemes-widget-testimonials.php
@@ -267,5 +267,5 @@ class Woothemes_Widget_Testimonials extends WP_Widget {
 } // End Class
 
 /* Register the widget. */
-add_action( 'widgets_init', create_function( '', 'return register_widget("Woothemes_Widget_Testimonials");' ), 1 );
+add_action( 'widgets_init', function() { return register_widget("Woothemes_Widget_Testimonials"); }, 1 );
 ?>


### PR DESCRIPTION
Eliminates a deprecated function call in class-woothemes-widget-testimonials.php replacing create_function() method which was deprecated in PHP 7.2.0, instead using an inline anonymous function, which still meets the "callable" criteria of the add_action method's second parameter.

the use of the deprecated create_function() method in conjunction with PHP 7.2 or later causes a warning to be thrown, which can make debugging more difficult if display errors is turned on (the display of the warning sends content headers before they may be expected, which can  interrupt other code which may only be able to run before headers have been sent).